### PR TITLE
Binary UUID Grammar & Blueprint support

### DIFF
--- a/src/Database/Schema/Grammar/MySqlGrammar.php
+++ b/src/Database/Schema/Grammar/MySqlGrammar.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Laratools\Database\Schema\Grammar;
+use Illuminate\Database\Schema\Grammars\MySqlGrammar as IlluminateMySqlGrammar;
+
+class MySqlGrammar extends IlluminateMySqlGrammar
+{
+    protected function typeBinaryUuid()
+    {
+        return 'binary(16)';
+    }
+}

--- a/src/Database/Schema/Grammar/MySqlGrammar.php
+++ b/src/Database/Schema/Grammar/MySqlGrammar.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Laratools\Database\Schema\Grammar;
+
 use Illuminate\Database\Schema\Grammars\MySqlGrammar as IlluminateMySqlGrammar;
 
 class MySqlGrammar extends IlluminateMySqlGrammar

--- a/src/Database/Schema/Grammar/SQLiteGrammar.php
+++ b/src/Database/Schema/Grammar/SQLiteGrammar.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Laratools\Database\Schema\Grammar;
+
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar as IlluminateSQLiteGrammar;
 
 class SQLiteGrammar extends IlluminateSQLiteGrammar

--- a/src/Database/Schema/Grammar/SQLiteGrammar.php
+++ b/src/Database/Schema/Grammar/SQLiteGrammar.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Laratools\Database\Schema\Grammar;
+use Illuminate\Database\Schema\Grammars\SQLiteGrammar as IlluminateSQLiteGrammar;
+
+class SQLiteGrammar extends IlluminateSQLiteGrammar
+{
+    protected function typeBinaryUuid()
+    {
+        return 'binary(16)';
+    }
+}

--- a/src/Providers/LaratoolsServiceProvider.php
+++ b/src/Providers/LaratoolsServiceProvider.php
@@ -2,8 +2,15 @@
 
 namespace Laratools\Providers;
 
+use Exception;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Schema\Grammars\MySqlGrammar as IlluminateMySqlGrammar;
+use Illuminate\Database\Schema\Grammars\SQLiteGrammar as IlluminateSQLiteGrammar;
+use Laratools\Database\Schema\Grammar\MySqlGrammar;
+use Laratools\Database\Schema\Grammar\SQLiteGrammar;
 
 class LaratoolsServiceProvider extends ServiceProvider
 {
@@ -25,7 +32,37 @@ class LaratoolsServiceProvider extends ServiceProvider
             /** @var Blueprint $this */
             return $this->addColumn('binaryUuid', $name);
         });
+
+        /** @var Connection $connection */
+        $connection = $this->app->make('db')->connection();
+        $connection->setSchemaGrammar($this->makeGrammar($connection));
     }
 
+    protected function makeGrammar(Connection $connection): Grammar
+    {
+        $original = $connection->getSchemaGrammar();
+        $enhanced = $this->getEnhancedGrammarFromIlluminate($original);
+
+        $enhanced->setTablePrefix($original->getTablePrefix());
+
+        return $enhanced;
+    }
+
+    protected function getEnhancedGrammarFromIlluminate(Grammar $original): Grammar
+    {
+        switch(get_class($original))
+        {
+            case IlluminateMySqlGrammar::class:
+                return new MySqlGrammar();
+            case IlluminateSQLiteGrammar::class:
+                return new SQLiteGrammar();
+            default:
+                throw new Exception(
+                    sprintf(
+                        'Only MySQL and SQLite grammars support binary uuids. [%s] was used',
+                        get_class($original)
+                    )
+                );
+        }
     }
 }

--- a/src/Providers/LaratoolsServiceProvider.php
+++ b/src/Providers/LaratoolsServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laratools\Providers;
 
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\ServiceProvider;
 
 class LaratoolsServiceProvider extends ServiceProvider
@@ -15,6 +16,16 @@ class LaratoolsServiceProvider extends ServiceProvider
 
     public function register()
     {
-        //
+        $this->registerBinaryUuid();
+    }
+
+    protected function registerBinaryUuid()
+    {
+        Blueprint::macro('binaryUuid', function (string $name = 'uuid') {
+            /** @var Blueprint $this */
+            return $this->addColumn('binaryUuid', $name);
+        });
+    }
+
     }
 }

--- a/src/Providers/LaratoolsServiceProvider.php
+++ b/src/Providers/LaratoolsServiceProvider.php
@@ -50,8 +50,7 @@ class LaratoolsServiceProvider extends ServiceProvider
 
     protected function getEnhancedGrammarFromIlluminate(Grammar $original): Grammar
     {
-        switch(get_class($original))
-        {
+        switch (get_class($original)) {
             case IlluminateMySqlGrammar::class:
                 return new MySqlGrammar();
             case IlluminateSQLiteGrammar::class:


### PR DESCRIPTION
Closes #18 

Adds blueprint support and grammar enhancers so binary uuids are supported out the box without any user modifications.