### PR TITLE
Remove 5.3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "minimum-stability": "stable",
     "require": {
         "php": "~7.0",
-        "illuminate/contracts": "~5.3.0|~5.4.0|~5.5.0|~5.6.0",
-        "illuminate/database": "~5.3.0|~5.4.0|~5.5.0|~5.6.0",
-        "illuminate/events": "~5.3.0|~5.4.0|~5.5.0|~5.6.0",
+        "illuminate/contracts": "~5.4.0|~5.5.0|~5.6.0",
+        "illuminate/database": "~5.4.0|~5.5.0|~5.6.0",
+        "illuminate/events": "~5.4.0|~5.5.0|~5.6.0",
         "ramsey/uuid": "^3.6"
     },
     "require-dev": {


### PR DESCRIPTION
Closes #21 

`Blueprint::macro` isn't available in 5.3. It's required for #22 